### PR TITLE
update bson version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The driver is available on crates.io. To use the MongoDB driver in your code, ad
 
 ```
 [dependencies]
-bson = "0.8.0"
+bson = "0.9.0"
 mongodb = "0.3.0"
 ```
 


### PR DESCRIPTION
Version 0.3.0 of the package on crates.io had the bson version changed to 0.9.0, this results in errors if the user tries to pass documents created with a different version of the bson package.

relevant commits
https://github.com/mongodb-labs/mongo-rust-driver-prototype/commit/f513ef350677b2ad9e62325030b27e93802bd7f5
https://github.com/mongodb-labs/mongo-rust-driver-prototype/commit/89919c44e2f0b2b293140ec57c5a27bb13f50305